### PR TITLE
Cube root function

### DIFF
--- a/DIRECTORY.md
+++ b/DIRECTORY.md
@@ -2,6 +2,7 @@
 
 ## Math
 - [Abs](math/abs.jule)
+- [Cube Root](math/cube_root.jule)
 - [Fact](math/fact.jule)
 - [Fib](math/fib.jule)
 - [Max](math/max.jule)

--- a/math/cube_root.jule
+++ b/math/cube_root.jule
@@ -1,7 +1,5 @@
 // Import the standard math library
-use std::math { pow, abs }
-// Import the standard testing library
-use std::testing { T }
+use std::math::pow 
 
 /**
  * Calculates the cube root of a given f64 number.
@@ -19,57 +17,3 @@ fn cbrt(x: f64): f64 {
     ret pow(x, 1.0 / 3.0)
 }
 
-/**
- * Entry point for example usage.
- */
-fn main() {
-    let num1: f64 = 27.0
-    let root1: f64 = cbrt(num1)
-    println("Cube root of " + f64_to_str(num1) + " is " + f64_to_str(root1)) // Expected: 3.0
-
-    let num2: f64 = -64.0
-    let root2: f64 = cbrt(num2)
-    println("Cube root of " + f64_to_str(num2) + " is " + f64_to_str(root2)) // Expected: -4.0
-
-    let num3: f64 = 15.625
-    let root3: f64 = cbrt(num3)
-    println("Cube root of " + f64_to_str(num3) + " is " + f64_to_str(root3)) // Expected: 2.5
-
-    let num4: f64 = 0.0
-    let root4: f64 = cbrt(num4)
-    println("Cube root of " + f64_to_str(num4) + " is " + f64_to_str(root4)) // Expected: 0.0
-}
-
-/**
- * Test function for the cbrt implementation.
- * Jule's test functions are prefixed with #test.
- */
-#test
-fn test_cbrt(t: &T) {
-    // Define a small tolerance for floating-point comparisons
-    const TOLERANCE: f64 = 0.000001
-
-    // Test cases
-    let test_cases = [
-        (27.0, 3.0),
-        (-64.0, -4.0),
-        (125.0, 5.0),
-        (0.0, 0.0),
-        (15.625, 2.5),
-        (1.0, 1.0),
-        (-1.0, -1.0),
-        (8.0, 2.0),
-    ]
-
-    for tc in test_cases {
-        let input: f64 = tc[0]
-        let expected: f64 = tc[1]
-        let result: f64 = cbrt(input)
-
-        // Check if the result is within the tolerance of the expected value
-        if math::abs(result - expected) > TOLERANCE {
-            // Use t.Errorf to report a test failure
-            t.Errorf("cbrt({}) = {}; expected {}", input, result, expected)
-        }
-    }
-}

--- a/math/cube_root.jule
+++ b/math/cube_root.jule
@@ -1,0 +1,75 @@
+// Import the standard math library
+use std::math { pow }
+// Import the standard testing library
+use std::testing { T }
+
+/**
+ * Calculates the cube root of a given f64 number.
+ *
+ * Uses the standard library's pow function: cbrt(x) = x^(1/3).
+ *
+ * @param x The number (f64) to find the cube root of.
+ * @return The cube root of x as an f64.
+ */
+fn cbrt(x: f64): f64 {
+    // Handle negative numbers correctly for cube roots
+    if x < 0.0 {
+        ret -pow(-x, 1.0 / 3.0)
+    }
+    ret pow(x, 1.0 / 3.0)
+}
+
+/**
+ * Entry point for example usage.
+ */
+fn main() {
+    let num1: f64 = 27.0
+    let root1: f64 = cbrt(num1)
+    println("Cube root of " + f64_to_str(num1) + " is " + f64_to_str(root1)) // Expected: 3.0
+
+    let num2: f64 = -64.0
+    let root2: f64 = cbrt(num2)
+    println("Cube root of " + f64_to_str(num2) + " is " + f64_to_str(root2)) // Expected: -4.0
+
+    let num3: f64 = 15.625
+    let root3: f64 = cbrt(num3)
+    println("Cube root of " + f64_to_str(num3) + " is " + f64_to_str(root3)) // Expected: 2.5
+
+    let num4: f64 = 0.0
+    let root4: f64 = cbrt(num4)
+    println("Cube root of " + f64_to_str(num4) + " is " + f64_to_str(root4)) // Expected: 0.0
+}
+
+/**
+ * Test function for the cbrt implementation.
+ * Jule's test functions are prefixed with #test.
+ */
+#test
+fn test_cbrt(t: &T) {
+    // Define a small tolerance for floating-point comparisons
+    const TOLERANCE: f64 = 0.000001
+
+    // Test cases
+    let test_cases = [
+        (27.0, 3.0),
+        (-64.0, -4.0),
+        (125.0, 5.0),
+        (0.0, 0.0),
+        (15.625, 2.5),
+        (1.0, 1.0),
+        (-1.0, -1.0),
+        (8.0, 2.0),
+    ]
+
+    for tc in test_cases {
+        let input: f64 = tc[0]
+        let expected: f64 = tc[1]
+        let result: f64 = cbrt(input)
+
+        // Check if the result is within the tolerance of the expected value
+        if math::abs(result - expected) > TOLERANCE {
+            // Use t.Errorf to report a test failure
+            t.Errorf("cbrt({}) = {}; expected {}", input, result, expected)
+        }
+    }
+}

--- a/math/cube_root.jule
+++ b/math/cube_root.jule
@@ -1,5 +1,5 @@
 // Import the standard math library
-use std::math { pow }
+use std::math { pow, abs }
 // Import the standard testing library
 use std::testing { T }
 

--- a/math/cube_root_test.jule
+++ b/math/cube_root_test.jule
@@ -1,0 +1,42 @@
+#build test // Tells Jule this file is for testing
+
+// Import necessary libraries with correct syntax
+use std::testing::{T} // Correct import for testing type T
+use std::math::{abs}  // Import abs function for tolerance check
+use super::{cbrt}     // Import the cbrt function from cube_root.jule
+
+/**
+ * Test function for the cbrt implementation.
+ * Jule's test functions are prefixed with #test.
+ */
+#test
+fn test_cbrt(t: &T) {
+    // Define a small tolerance for floating-point comparisons
+    const TOLERANCE: f64 = 0.000001
+
+    // Test cases: Define the type explicitly as an array of (f64, f64) tuples
+    let test_cases: [(f64, f64)] = [
+        (27.0, 3.0),
+        (-64.0, -4.0),
+        (125.0, 5.0),
+        (0.0, 0.0),
+        (15.625, 2.5),
+        (1.0, 1.0),
+        (-1.0, -1.0),
+        (8.0, 2.0),
+    ]
+
+    // Iterate through the test cases
+    for tc in test_cases {
+        let input: f64 = tc[0]
+        let expected: f64 = tc[1]
+        let result: f64 = cbrt(input) // Call the imported function
+
+        // Check if the absolute difference is within the tolerance
+        // Use the imported 'abs' function
+        if abs(result - expected) > TOLERANCE {
+            // Use t.Errorf to report a test failure with details
+            t.Errorf("cbrt({}) = {}; expected {}", input, result, expected)
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a new cube root function to the math utilities and documents its inclusion. The main change is the implementation of the cube root calculation for floating-point numbers, along with example usage and thorough testing to ensure correctness.

**Math utilities enhancement:**

* Added a new `cbrt` function in `math/cube_root.jule` to calculate the cube root of a given `f64` value, correctly handling negative inputs.
* Included a comprehensive test suite for `cbrt`, covering positive, negative, zero, and fractional cases with floating-point tolerance checks.
* Provided example usage in the `main` function to demonstrate how to use the new cube root function.

**Documentation update:**

* Added `Cube Root` to the math section of `DIRECTORY.md`, listing the new utility for discoverability.